### PR TITLE
Support GHC 9.0.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20201213
+# version: 0.11.20210222
 #
-# REGENDATA ("0.11.20201213",["github","./attoparsec.cabal","--no-benchmarks","--branches","master"])
+# REGENDATA ("0.11.20210222",["github","./attoparsec.cabal","--no-benchmarks","--branches","master"])
 #
 name: Haskell-CI
 on:
@@ -22,23 +22,36 @@ on:
       - master
 jobs:
   linux:
-    name: Haskell-CI Linux
+    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
+    continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - ghc: 8.10.1
-          - ghc: 8.8.1
+          - ghc: 9.0.1
+            allow-failure: false
+          - ghc: 8.10.4
+            allow-failure: false
+          - ghc: 8.8.4
+            allow-failure: false
           - ghc: 8.6.5
+            allow-failure: false
           - ghc: 8.4.4
+            allow-failure: false
           - ghc: 8.2.2
+            allow-failure: false
           - ghc: 8.0.2
+            allow-failure: false
           - ghc: 7.10.3
+            allow-failure: false
           - ghc: 7.8.4
+            allow-failure: false
           - ghc: 7.6.3
+            allow-failure: false
           - ghc: 7.4.2
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -47,7 +60,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2
+          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
         env:
           GHC_VERSION: ${{ matrix.ghc }}
       - name: Set PATH and environment variables
@@ -60,12 +73,13 @@ jobs:
           echo "HC=$HC" >> $GITHUB_ENV
           echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
           echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.2/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--disable-benchmarks" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
+          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
           GHC_VERSION: ${{ matrix.ghc }}
@@ -77,7 +91,7 @@ jobs:
           mkdir -p $CABAL_DIR
           cat >> $CABAL_CONFIG <<EOF
           remote-build-reporting: anonymous
-          write-ghc-environment-files: always
+          write-ghc-environment-files: never
           remote-repo-cache: $CABAL_DIR/packages
           logs-dir:          $CABAL_DIR/logs
           world-file:        $CABAL_DIR/world
@@ -108,14 +122,19 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+          cabal-plan --version
       - name: checkout
         uses: actions/checkout@v2
         with:
           path: source
+      - name: initial cabal.project for sdist
+        run: |
+          touch cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
+          cat cabal.project
       - name: sdist
         run: |
           mkdir -p sdist
-          cd source || false
           $CABAL sdist all --output-dir $GITHUB_WORKSPACE/sdist
       - name: unpack
         run: |
@@ -147,14 +166,14 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
       - name: install dependencies
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only all
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only all
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j2 all
       - name: build w/o tests
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: build
         run: |
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -6,7 +6,7 @@ category:        Text, Parsing
 author:          Bryan O'Sullivan <bos@serpentine.com>
 maintainer:      Bryan O'Sullivan <bos@serpentine.com>, Ben Gamari <ben@smart-cactus.org>
 stability:       experimental
-tested-with:     GHC == 7.4.2, GHC ==7.6.3, GHC ==7.8.4, GHC ==7.10.3, GHC ==8.0.2, GHC ==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.1, GHC==8.10.1
+tested-with:     GHC == 7.4.2, GHC ==7.6.3, GHC ==7.8.4, GHC ==7.10.3, GHC ==8.0.2, GHC ==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.4, GHC == 9.0.1
 synopsis:        Fast combinator parsing for bytestrings and text
 cabal-version:   2.0
 homepage:        https://github.com/bgamari/attoparsec
@@ -46,7 +46,7 @@ library
                  scientific >= 0.3.1 && < 0.4,
                  transformers >= 0.2 && (< 0.4 || >= 0.4.1.0) && < 0.6,
                  text >= 1.1.1.3,
-                 ghc-prim <0.7
+                 ghc-prim <0.8
   if impl(ghc < 7.4)
     build-depends:
       bytestring < 0.10.4.0


### PR DESCRIPTION
I could compile with GHC 9.0.1 after bumping the upper bound for `ghc-prim`.

Could you enable the issues for this repository, please.

Blocking https://github.com/agda/agda/issues/4955.

If you accept this PR, please update the revision in Hackage.